### PR TITLE
Potential fix for code scanning alert no. 30: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-tagging.yml
+++ b/.github/workflows/validate-tagging.yml
@@ -1,4 +1,6 @@
 name: Validate Docker Hub Tagging
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/magicalyak/nzbgetvpn/security/code-scanning/30](https://github.com/magicalyak/nzbgetvpn/security/code-scanning/30)

To fix the problem, add an explicit `permissions` key to the workflow to limit the default token to the least privileges required. Since all the steps in the `validate-tags` job involve reading repository contents and do not require write access (no issue creation, no repo modification), set `permissions: contents: read` at the top level. This ensures all jobs inherit the minimum scope—if a job later needs more, it can override locally. 

**Change to make:**  
- At the top of `.github/workflows/validate-tagging.yml`, after the `name:` line, add:
  ```yaml
  permissions:
    contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
