### PR TITLE
Critical: Revert USER directive that breaks container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 All notable changes to nzbgetvpn will be documented in this file.
 
+## [v25.3.4] - 2025-09-20
+
+### 🔄 Revert USER Directive Changes
+
+#### Critical Fix
+- **Removed USER directive**: Was breaking s6-overlay initialization
+- **Restored v25.3.1 approach**: No USER directive, proper functionality
+- **Kept security updates**: Base image and package updates retained
+
+#### Why This Change
+- LinuxServer's s6-overlay REQUIRES root to initialize
+- USER directive prevents proper container startup
+- PUID/PGID mechanism already provides non-root execution
+- v25.3.1 had an A score without USER directive
+
+#### Technical Details
+- s6-overlay handles privilege dropping via PUID/PGID
+- More flexible than fixed USER directive
+- Docker Scout's "no non-root user" is a false positive for s6 containers
+- Container services DO run as non-root (PUID/PGID)
+
+#### Expected Outcome
+- Container functionality restored
+- Docker Scout score should return to A (as in v25.3.1)
+- Full backward compatibility maintained
+
 ## [v25.3.3] - 2025-09-20
 
 ### 🔒 Docker Scout Compliance Fixes


### PR DESCRIPTION
## 🚨 CRITICAL FIX

The USER directive added in v25.3.2-3 **breaks the container**!

## The Problem

Docker Scout wants a non-root USER, but LinuxServer's s6-overlay REQUIRES root to start. These are incompatible requirements.

## Why Scores Changed

| Version | USER Directive | Docker Scout Score | Container Works? |
|---------|---------------|-------------------|------------------|
| v25.3.1 | None | **A** ✅ | Yes ✅ |
| v25.3.2 | Added (switched back to root) | D ❌ | Maybe |
| v25.3.3 | USER abc (final) | D ❌ | **No** ❌ |

## The Solution

**Revert to v25.3.1 approach** - No USER directive at all.

### Why This Is Correct

1. **s6-overlay REQUIRES root** to initialize
2. **PUID/PGID provides non-root execution** - more flexible than USER
3. **Docker Scout's check is a false positive** for s6-overlay containers
4. **Services DO run as non-root** via PUID/PGID mechanism

## Changes in This PR

- ✅ Removed all USER directives
- ✅ Kept security updates (base image v25.3, package updates)
- ✅ Added clear documentation about why USER breaks s6
- ✅ Restores full functionality

## Expected Results

- Container works properly again
- Docker Scout score returns to **A** (as in v25.3.1)
- Full backward compatibility

## Testing

After v25.3.4 is built:
1. Container should start properly
2. Services run as PUID/PGID (non-root)
3. Docker Scout should show A score

## Important Note

Docker Scout's "no non-root user" check doesn't understand s6-overlay's privilege dropping mechanism. The container IS secure and DOES run services as non-root through PUID/PGID.