### PR TITLE
fix: Remove invalid --append flag from docker buildx imagetools create

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -328,7 +328,7 @@ jobs:
           echo "Docker Hub tags to create: $DOCKERHUB_TAGS"
           
           # Create manifest
-          docker buildx imagetools create --append \
+          docker buildx imagetools create \
             $DOCKERHUB_TAGS \
             $(printf '${{ env.REGISTRY_DOCKERHUB }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
           


### PR DESCRIPTION
## Summary

Removes the invalid `--append` flag from `docker buildx imagetools create` command in the build workflow, which was causing build failures.

## Changes

- Removed `--append` flag from line 331 in `.github/workflows/build-and-publish.yml`

## Problem

The `--append` flag is not a valid option for the `docker buildx imagetools create` command and was causing workflow failures when trying to create multi-architecture manifests.

## Test plan

- Verify the workflow runs successfully with version tags
- Confirm multi-architecture manifests are created correctly for both Docker Hub and GHCR